### PR TITLE
Additional Legacy Rate Card updates

### DIFF
--- a/Apis.cs
+++ b/Apis.cs
@@ -221,7 +221,7 @@ namespace AzureBillingV2
                 if (result.GetRawResponse().Status < 300)
                 {
                     tracker.CostDataBlobName = targetClient.Uri.ToString();
-                    tracker.StatusMessage = "Successfully saved report to Blob storage";
+                    tracker.StatusMessage += "Successfully saved report to Blob storage. ";
                     return tracker;
                 }
                 else
@@ -260,6 +260,13 @@ namespace AzureBillingV2
                     if (mgSubscriptions.Count == 0)
                     {
                         return (mgSubscriptions, $"No subscriptions found for Management Group {managementGroupId}");
+                    }
+                    else
+                    {
+                        mgSubscriptions.ForEach(s =>
+                        {
+                            s.TenantId = tenantId;
+                        });
                     }
                     return (mgSubscriptions, string.Empty);
                 }
@@ -394,7 +401,7 @@ namespace AzureBillingV2
                 if (writeOperation.GetRawResponse().Status < 300)
                 {
                     tracker.CostDataBlobName = targetClient.Uri.ToString();
-                    tracker.StatusMessage = "Successfully saved report to Blob storage. ";
+                    tracker.StatusMessage += "Successfully saved rate card mapped report to Blob storage. ";
                     return tracker;
                 }
                 else

--- a/Models/ReportTracking.cs
+++ b/Models/ReportTracking.cs
@@ -21,8 +21,11 @@ namespace AzureBillingV2.Models
         [JsonPropertyName("reportBlobSas")]
         public string ReportBlobSas { get; set; }
 
-        [JsonPropertyName("destinationBlobName")]
-        public string DestinationBlobName { get; set; }
+        [JsonPropertyName("costDataBlobName")]
+        public string CostDataBlobName { get; set; }
+
+        [JsonPropertyName("rateCardBlobName")]
+        public string RateCardBlobName { get; set; }
 
         [JsonPropertyName("success")]
         public bool Success { get; set; } = true;
@@ -35,5 +38,6 @@ namespace AzureBillingV2.Models
 
         [JsonIgnore]
         public List<BillingData> CostInfo { get; set; }
+
     }
 }

--- a/Models/ReportTracking.cs
+++ b/Models/ReportTracking.cs
@@ -15,6 +15,9 @@ namespace AzureBillingV2.Models
         [JsonPropertyName("subscriptionId")]
         public string SubscriptionId { get; set; }
 
+        [JsonPropertyName("tenantId")]
+        public string TenantId { get; set; }
+
         [JsonPropertyName("reportStatusUrl")]
         public string ReportStatusUrl { get; set; }
 

--- a/Orchestration.cs
+++ b/Orchestration.cs
@@ -1,0 +1,175 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AzureBillingV2.Models;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace AzureBillingV2
+{
+    public class Orchestration
+    {
+        private Apis apis;
+        private readonly ILogger _logger;
+        public Orchestration(Apis apis, ILoggerFactory loggerFactory)
+        {
+            this.apis = apis;
+            _logger = loggerFactory.CreateLogger<Orchestration>();
+        }
+        public async Task<(List<ReportTracking>, List<ReportTracking>)> GenerateCostDetailsReports(List<ReportTracking> subs, DateTime startDateTime, DateTime endDateTime)
+        {
+            var successfulReports = new List<ReportTracking>();
+            var failedReports = new List<ReportTracking>();
+
+            // Generate cost details report for each subscription
+            _logger.LogInformation($"Generating cost detail reports for {subs.Count()} subscriptions");
+            List<Task<ReportTracking>> generateTasks = new List<Task<ReportTracking>>();
+            foreach (var sub in subs)
+            {
+                generateTasks.Add(apis.RequestCostDetailsReport(sub, startDateTime, endDateTime));
+            }
+            var generateResults = await Task.WhenAll(generateTasks.ToArray());
+
+            //Update lists of success and failed.
+            successfulReports = generateResults.Where(t => !string.IsNullOrEmpty(t.ReportStatusUrl)).ToList();
+            failedReports.AddRange(generateResults.Where(t => !t.Success));
+
+            _logger.LogInformation($"Found {successfulReports.Count()} successful generation tasks");
+
+            return (successfulReports, failedReports);
+        }
+
+        public async Task<(List<ReportTracking>, List<ReportTracking>)> GetReportsStatusAndBlobUrls(List<ReportTracking> reports)
+        {
+            var successfulReports = new List<ReportTracking>();
+            var failedReports = new List<ReportTracking>();
+
+            // Get list of report URIs
+            _logger.LogInformation($"Checking report status and getting report Sas URLs for {reports.Count()} reports");
+            List <Task<ReportTracking>> reportTasks = new List<Task<ReportTracking>>();
+            foreach (var task in reports)
+            {
+                reportTasks.Add(apis.GetReportStatusBlobUrl(task, task.TenantId));
+            }
+            var reportResults = await Task.WhenAll(reportTasks.ToArray());
+
+            //Update lists of success and failed.
+            successfulReports = reportResults.Where(t => t.Success).ToList();
+            failedReports.AddRange(reportResults.Where(t => !t.Success));
+            _logger.LogInformation($"Found {successfulReports.Count()} successful reports");
+
+            return (successfulReports, failedReports);
+        }
+
+        internal async Task<(List<ReportTracking>,List<ReportTracking>)> GetLegacyRateCardsForSubs(List<ReportTracking> reports)
+        {
+            var successfulReports = new List<ReportTracking>();
+            var failedReports = new List<ReportTracking>();
+
+            _logger.LogInformation($"Getting Legacy Rate Card information for {reports.Count()} subscriptions");
+            var rateCardTasks = new List<Task<ReportTracking>>();
+            foreach (var tracker in reports)
+            {
+                rateCardTasks.Add(apis.GetRateCardInformation(tracker, tracker.TenantId));
+            }
+            var rateCardResults = await Task.WhenAll(rateCardTasks.ToArray());
+            //Update lists of success and failed.
+            successfulReports = rateCardResults.Where(t => t.Success).ToList();
+            failedReports.AddRange(rateCardResults.Where(t => !t.Success));
+
+            _logger.LogInformation($"Retrieved Legacy Rate Card information for {successfulReports.Count()} subscriptions");
+            return (successfulReports, failedReports);
+        }
+
+        internal async Task<(List<ReportTracking>, List<ReportTracking>)> MapRateCardsToCostReports(List<ReportTracking> reports)
+        {
+            var successfulReports = new List<ReportTracking>();
+            var failedReports = new List<ReportTracking>();
+
+            _logger.LogInformation($"Mapping Legacy Rate Card information to billing data for {reports.Count()} subscriptions");
+            var mappingTasks = new List<Task<ReportTracking>>();
+            foreach (var tracker in reports)
+            {
+                mappingTasks.Add(apis.MapRateCardToCostReport(tracker));
+            }
+            var mappingResults = await Task.WhenAll(mappingTasks.ToArray());
+            //Update lists of success and failed.
+            successfulReports = mappingResults.Where(t => t.Success).ToList();
+            failedReports.AddRange(mappingResults.Where(t => !t.Success));
+
+            _logger.LogInformation($"Successfully mapped Legacy Rate Card information to billing data for {successfulReports.Count()} subscriptions");
+            return (successfulReports, failedReports);
+        }
+
+        internal async Task<(List<ReportTracking>, List<ReportTracking>)> SaveMappedReportsToStorage(List<ReportTracking> reports, string filePrefix, DateOnly startDate, string containerName, string targetConnectionString)
+        {
+            var successfulReports = new List<ReportTracking>();
+            var failedReports = new List<ReportTracking>();
+            
+            _logger.LogInformation($"Saving mapped billing data for {reports.Count()} subscriptions");
+            var writeTasks = new List<Task<ReportTracking>>();
+            foreach (var tracker in reports)
+            {
+                tracker.CostDataBlobName = $"{startDate.ToString("yyyy-MM-dd")}/{filePrefix}-{tracker.SubscriptionId}.csv";
+
+                writeTasks.Add(apis.SaveMappedDataToStorage(tracker, containerName, targetConnectionString));
+            }
+            var writeResults = await Task.WhenAll(writeTasks.ToArray());
+            //Update lists of success and failed.
+            successfulReports = writeResults.Where(t => t.Success).ToList();
+            failedReports.AddRange(writeResults.Where(t => !t.Success));
+            _logger.LogInformation($"Saved mapped billing data for {successfulReports.Count()} subscriptions");
+
+            return (successfulReports, failedReports);
+        }
+
+        internal async Task<(List<ReportTracking>, List<ReportTracking>)> SaveSubscriptionsRateCardData(List<ReportTracking> reports, DateOnly startDate, string containerName, string targetConnectionString)
+        {
+            var successfulReports = new List<ReportTracking>();
+            var failedReports = new List<ReportTracking>();
+            
+            _logger.LogInformation($"Saving rate card data for {reports.Count()} subscriptions");
+            var rateCardBlobTasks = new List<Task<ReportTracking>>();
+            foreach (var tracker in reports)
+            {
+                tracker.RateCardBlobName = $"{startDate.ToString("yyyy-MM-dd")}/RateCard-{tracker.SubscriptionId}.json";
+                rateCardBlobTasks.Add(apis.SaveRateCardToStorage(tracker, containerName, targetConnectionString));
+            }
+            var rateCardBlobResults = await Task.WhenAll(rateCardBlobTasks.ToArray());
+            //Update lists of success and failed.
+            successfulReports = rateCardBlobResults.Where(t => t.Success).ToList();
+            failedReports.AddRange(rateCardBlobResults.Where(t => !t.Success));
+
+            _logger.LogInformation($"Saved rate card data for {successfulReports.Count()} subscriptions");
+
+            return (successfulReports, failedReports);
+        }
+
+        internal async Task<(List<ReportTracking>, List<ReportTracking>)> CopyReportBlobsToTargetStorage(List<ReportTracking> reports, string filePrefix, DateOnly startDate, string containerName, string targetConnectionString)
+        {
+            var successfulReports = new List<ReportTracking>();
+            var failedReports = new List<ReportTracking>();
+            
+            // Copy Reports to Blob Storage
+            _logger.LogInformation($"Copying {reports.Count()} reports to destination Blob Container");
+            var blobCopyTasks = new List<Task<ReportTracking>>();
+            foreach (var tracker in reports)
+            {
+                tracker.CostDataBlobName = $"{startDate.ToString("yyyy-MM-dd")}/{filePrefix}-{tracker.SubscriptionId}.csv";
+                blobCopyTasks.Add(apis.SaveBlobToStorage(tracker, containerName, targetConnectionString));
+            }
+            var blobCopyResults = await Task.WhenAll(blobCopyTasks.ToArray());
+            _logger.LogInformation($"Copied {blobCopyResults.Count()} reports to blob storage");
+
+            //Update lists of success and failed.
+            successfulReports = blobCopyResults.Where(t => t.Success).ToList();
+            failedReports.AddRange(blobCopyResults.Where(t => !t.Success));
+            _logger.LogInformation($"Successfully copied {successfulReports.Count()} reports to destination Blob Container");
+
+            return (successfulReports, failedReports);
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -20,6 +20,7 @@ var builder = new HostBuilder()
     .ConfigureServices(services =>
     {
         services.AddSingleton<AzureBillingV2.Apis>();
+        services.AddSingleton<AzureBillingV2.Orchestration>();
         services.AddSingleton<IConfigurationRoot>(config);
     });
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ The HTTP request will return a JSON summary of the report generation as per the 
   - `ManagementGroupId` - the value need to be the Guid Id value of the mangement group
   - `StorageConnectionString` - connection string to the Azure storage account
   - `ContainerName` - name of the storage container to save the billing report CSV. If is does not exist, it will be created at runtime. The name must adhere to the [naming rules](https://learn.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#container-names).
-  - If you need to leverage the [Legacy RateCard APIs](https://learn.microsoft.com/en-us/previous-versions/azure/reference/mt219004(v%3dazure.100)), you can add a configuration setting `UseLegacyRateCard` with the value `true`
+  - If you need to leverage the [Legacy RateCard APIs](https://learn.microsoft.com/en-us/previous-versions/azure/reference/mt219004(v%3dazure.100)), you can add a configuration setting `UseLegacyRateCard` with the value `true` (default: `false`)
+    - Additional configuraiton options when using legacy rate card:
+      - `SaveRateCardData` - whether or not to save the Rate Card json file to storage (default: `true`)
+      - `SaveRawBillingReport` - whether or not to save raw CSV file (no mapped cost data) to storage (default: `true`)
 
 **NOTE:** If you have a large number of subscriptions in your management group, you may need to deploy the Function to something other than the "Consumption" tier. This is because the Consumption tier will timeout after 5 minutes.

--- a/appsettings.json
+++ b/appsettings.json
@@ -8,7 +8,8 @@
     "StorageConnectionString": "",
     "ContainerName": "",
     "UseLegacyRateCard": true,
-    "SaveRateCardData": true
+    "SaveRateCardData": true,
+    "SaveRawBillingReport" :  true
   },
  
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -4,8 +4,11 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "ManagementGroupId": "",
+    "TenantId": "",
     "StorageConnectionString": "",
-    "ContainerName": ""
+    "ContainerName": "",
+    "UseLegacyRateCard": true,
+    "SaveRateCardData": true
   },
  
 }


### PR DESCRIPTION
Updating the `CostInBillingCurrency`  field with calculated rate when `UseLegacyRateCard` is enabled
Refactored and cleaned orchestration of tasks

When using legacy rate card, new options to also save the Rate Card JSON and Raw cost detail report. 
To disable, add `"SaveRateCardData" : false` and/or `"SaveRawBillingReport": false` app setting